### PR TITLE
fix(firmware): return gps transport status

### DIFF
--- a/9_Firmware/9_1_Microcontroller/9_1_1_C_Cpp_Libraries/gps_handler.cpp
+++ b/9_Firmware/9_1_Microcontroller/9_1_1_C_Cpp_Libraries/gps_handler.cpp
@@ -1,6 +1,7 @@
 // gps_handler.cpp
 #include "gps_handler.h"
 #include <cmath>
+#include <cstdio>
 
 // UART handle for communication with GUI
 static UART_HandleTypeDef* gui_huart = NULL;
@@ -16,6 +17,10 @@ void GPS_Init(UART_HandleTypeDef* huart)
 
 uint8_t GPS_IsDataValid(GPS_Data_t* gps_data)
 {
+    if (gps_data == NULL) {
+        return 0;
+    }
+
     // Check if GPS data is within valid ranges
     if (gps_data->latitude < -90.0 || gps_data->latitude > 90.0)
         return 0;
@@ -27,11 +32,11 @@ uint8_t GPS_IsDataValid(GPS_Data_t* gps_data)
     return 1;
 }
 
-void GPS_ProcessData(GPS_Data_t* gps_data)
+bool GPS_ProcessData(GPS_Data_t* gps_data)
 {
     // Validate GPS data
     if (!GPS_IsDataValid(gps_data)) {
-        return;
+        return false;
     }
     
     // Update current GPS data
@@ -39,12 +44,14 @@ void GPS_ProcessData(GPS_Data_t* gps_data)
     current_gps.timestamp = HAL_GetTick();
     
     // Send to GUI
-    GPS_SendToGUI(&current_gps);
+    return GPS_SendToGUI(&current_gps);
 }
 
-void GPS_SendToGUI(GPS_Data_t* gps_data)
+bool GPS_SendToGUI(GPS_Data_t* gps_data)
 {
-    if (gui_huart == NULL) return;
+    if (gui_huart == NULL || gps_data == NULL) {
+        return false;
+    }
     
     // Create packet: "GPS:lat,lon,alt\r\n"
     char buffer[64];
@@ -55,16 +62,20 @@ void GPS_SendToGUI(GPS_Data_t* gps_data)
                       gps_data->longitude,
                       gps_data->altitude);
     
-    if (len > 0 && len < (int)sizeof(buffer)) {
-        // Send via UART3 to GUI
-        HAL_UART_Transmit(gui_huart, (uint8_t*)buffer, len, 1000);
+    if (len <= 0 || len >= (int)sizeof(buffer)) {
+        return false;
     }
+
+    // Send via UART3 to GUI
+    return HAL_UART_Transmit(gui_huart, (uint8_t*)buffer, len, 1000) == HAL_OK;
 }
 
 // Alternative binary protocol version (more efficient)
-void GPS_SendBinaryToGUI(GPS_Data_t* gps_data)
+bool GPS_SendBinaryToGUI(GPS_Data_t* gps_data)
 {
-    if (gui_huart == NULL) return;
+    if (gui_huart == NULL || gps_data == NULL) {
+        return false;
+    }
     
     // Binary packet structure:
     // [Header 4 bytes][Latitude 8 bytes][Longitude 8 bytes][Altitude 4 bytes][Pitch 4 bytes][CRC 2 bytes]
@@ -99,7 +110,7 @@ void GPS_SendBinaryToGUI(GPS_Data_t* gps_data)
         packet[20 + i] = (alt_bits >> (24 - i*8)) & 0xFF;
     }
     
-    // Convert float altitude to bytes (big-endian)
+    // Convert float pitch to bytes (big-endian)
     uint32_t pitch_bits;
     memcpy(&pitch_bits, &gps_data->pitch, sizeof(float));
     for(int i = 0; i < 4; i++) {
@@ -115,5 +126,5 @@ void GPS_SendBinaryToGUI(GPS_Data_t* gps_data)
     packet[29] = crc & 0xFF;
     
     // Send binary packet
-    CDC_Transmit_FS(packet, sizeof(packet));
+    return CDC_Transmit_FS(packet, sizeof(packet)) == USBD_OK;
 }

--- a/9_Firmware/9_1_Microcontroller/9_1_1_C_Cpp_Libraries/gps_handler.h
+++ b/9_Firmware/9_1_Microcontroller/9_1_1_C_Cpp_Libraries/gps_handler.h
@@ -5,6 +5,7 @@
 #include "main.h"
 #include "usb_device.h"
 #include "usbd_cdc_if.h"
+#include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
 
@@ -21,9 +22,9 @@ typedef struct {
 } GPS_Data_t;
 
 void GPS_Init(UART_HandleTypeDef* huart);
-void GPS_ProcessData(GPS_Data_t* gps_data);
-void GPS_SendToGUI(GPS_Data_t* gps_data);
-void GPS_SendBinaryToGUI(GPS_Data_t* gps_data);
+bool GPS_ProcessData(GPS_Data_t* gps_data);
+bool GPS_SendToGUI(GPS_Data_t* gps_data);
+bool GPS_SendBinaryToGUI(GPS_Data_t* gps_data);
 uint8_t GPS_IsDataValid(GPS_Data_t* gps_data);
 
 #ifdef __cplusplus

--- a/9_Firmware/9_1_Microcontroller/9_1_3_C_Cpp_Code/main.cpp
+++ b/9_Firmware/9_1_Microcontroller/9_1_3_C_Cpp_Code/main.cpp
@@ -1526,9 +1526,12 @@ int main(void)
 
   GPS_Data_t gps_data;
   // Binary packet structure:
-  // [Header 4 bytes][Latitude 8 bytes][Longitude 8 bytes][Altitude 4 bytes][CRC 2 bytes]
+  // [Header 4 bytes][Latitude 8 bytes][Longitude 8 bytes][Altitude 4 bytes][Pitch 4 bytes][CRC 2 bytes]
   gps_data = {RADAR_Latitude, RADAR_Longitude, RADAR_Altitude, Pitch_Sensor, HAL_GetTick()};
-  GPS_SendBinaryToGUI(&gps_data);
+  if (!GPS_SendBinaryToGUI(&gps_data)) {
+      const uint8_t gps_send_error[] = "GPS binary send failed\r\n";
+      HAL_UART_Transmit(&huart3, (uint8_t*)gps_send_error, sizeof(gps_send_error) - 1, 1000);
+  }
 
   // Check if start flag was received and settings are ready
   do{


### PR DESCRIPTION
## Summary
`gps_handler.cpp` dereferenced a pointer before null-checking it, ignored UART/CDC transmit return values, and had an inverted serialization comment for `pitch`. Transport failures were silently discarded with no signal to the caller.

## Root cause
- `gps_handler.cpp`: null dereference possible before guard check
- `gps_handler.cpp`: `HAL_UART_Transmit` and `CDC_Transmit_FS` return values were ignored
- `main.cpp`: the first binary GPS packet send failure was never checked
- `gps_handler.cpp`: the `pitch` serialization comment still said altitude

## Changes
- `gps_handler.h`: `GPS_ProcessData()`, `GPS_SendToGUI()`, and `GPS_SendBinaryToGUI()` now return `bool`
- `gps_handler.cpp`: added null guards before pointer dereference
- `gps_handler.cpp`: return `false` on UART/CDC send failure so callers can react
- `gps_handler.cpp`: corrected the `pitch` serialization comment
- `main.cpp`: log the first binary GPS send failure when `GPS_SendBinaryToGUI()` returns `false`

## Test
- Code review only in this environment
- No local CubeIDE build was possible from this worktree due to missing HAL header paths

> Note: maintainer build validation welcome.

## Scope
`gps_handler.h`, `gps_handler.cpp`, and `main.cpp` (GPS call site only).
Does not touch GY85, ADAR, FPGA, GUI, or vendored HAL/no_os_* files.

## Related
Companion to `fix/gy85-i2c-status`: both PRs surface peripheral transport failures instead of silently accepting them.