### PR TITLE
docs: fix FPGA part number, dead paths, and add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+# Contributing to PLFM_RADAR (AERIS-10)
+
+Thanks for your interest in the project! This guide covers the basics
+for getting a change reviewed and merged.
+
+## Getting started
+
+1. Fork the repository and create a topic branch from `develop`.
+2. Keep generated outputs (Vivado projects, bitstreams, build logs)
+   out of version control — the `.gitignore` already covers most of
+   these.
+
+## Repository layout
+
+| Path | Contents |
+|------|----------|
+| `4_Schematics and Boards Layout/` | KiCad schematics, Gerbers, BOM/CPL |
+| `9_Firmware/9_2_FPGA/` | Verilog RTL, constraints, testbenches, build scripts |
+| `9_Firmware/9_2_FPGA/formal/` | SymbiYosys formal-verification wrappers |
+| `9_Firmware/9_2_FPGA/scripts/` | Vivado TCL build & debug scripts |
+| `9_Firmware/9_3_GUI/` | Python radar dashboard (Tkinter + matplotlib) |
+| `docs/` | GitHub Pages documentation site |
+
+## Before submitting a pull request
+
+- **Python** — verify syntax: `python3 -m py_compile <file>`
+- **Verilog** — if you have Vivado, run the relevant `build*.tcl`;
+  if not, note which scripts your change affects
+- **Whitespace** — `git diff --check` should be clean
+- Keep PRs focused: one logical change per PR is easier to review
+
+## Areas where help is especially welcome
+
+See the list in [README.md](README.md#-contributing).
+
+## Questions?
+
+Open a GitHub issue — that way the discussion is visible to everyone.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The AERIS-10 main sub-systems are:
   - **2x Microwave Mixers (LT5552)** - For up-conversion and IF-down-conversion
   - **4x 4-Channel Phase Shifters (ADAR1000)** - For RX and TX chain beamforming
   - **16x Front End Chips (ADTR1107)** - Used for both Low Noise Amplifying (RX) and Power Amplifying (TX) stages
-  - **XC7A100T FPGA** - Handles RADAR Signal Processing:
+  - **XC7A50T FPGA** - Handles RADAR Signal Processing on the upstream FTG256 board:
     - PLFM Chirps generation via the DAC
     - Raw ADC data read
     - Automatic Gain Control (AGC)
@@ -150,11 +150,11 @@ To keep the repository root clean and make artifacts easy to find, place generat
 
 ### Hardware Assembly
 
-1. **Order PCBs**: All Gerber files are available in `/4_Schematics and Boards Layout`
-2. **Source Components**: Bill of materials (BOM) in `/4_Schematics and Boards Layout/4_7_Production Files`
-3. **Assembly**: Follow the assembly guide in `/10_docs/assembly_guide.md`
-4. **Antenna**: Choose appropriate array for your version
-5. **Enclosure**: 3D printable files in `/10_docs/Hardware/Enclosure`
+1. **Order PCBs**: Production outputs are under `/4_Schematics and Boards Layout/4_7_Production Files`
+2. **Source Components**: BOM/CPL files are co-located under `/4_Schematics and Boards Layout/4_7_Production Files`
+3. **Assembly**: Use the schematics in `/4_Schematics and Boards Layout/4_6_Schematics` together with the production outputs above; a standalone assembly guide is not currently tracked
+4. **Antenna**: Choose appropriate array files for your target variant
+5. **Enclosure**: Mechanical drawings currently live in `/8_Utils/Mechanical_Drawings`
 
 ## 📜 License
 
@@ -207,7 +207,7 @@ Comprehensive documentation is available in the `/docs` folder and served via Gi
 
 ## 🤝 Contributing
 
-We welcome contributions! Please see our [Contributing Guidelines](/CONTRIBUTING.md) for details.
+We welcome contributions! Please see our [Contributing Guidelines](/CONTRIBUTING.md) for details on repo layout, branch workflow, and basic PR checks.
 
 Areas where help is especially appreciated:
 - **RF Engineers**: Review designs, optimize antenna performance


### PR DESCRIPTION
Closes #37

## Summary

- **FPGA part number** (line 52): XC7A100T → XC7A50T to match the XDC correction note (`constraints/xc7a50t_ftg256.xdc`, lines 9-11)
- **Hardware Assembly section** (lines 153-157): replace dead `/10_docs/` paths with tracked locations (`4_6_Schematics`, `4_7_Production Files`, `8_Utils/Mechanical_Drawings`)
- **Contributing section** (line 210): update text to reference `CONTRIBUTING.md`
- **CONTRIBUTING.md**: add a minimal starter file covering repo layout, branch workflow, and PR checklist — feel free to reshape to your preferences

## Validation

- `git diff --check` — clean
- All referenced paths verified to exist on disk
- No functional code changes