### PR TITLE
fix: CI cross-layer test skip, golden ref ADC offset, GUI_V6 attribute, concat parser

### DIFF
--- a/9_Firmware/9_2_FPGA/tb/cosim/real_data/golden_reference.py
+++ b/9_Firmware/9_2_FPGA/tb/cosim/real_data/golden_reference.py
@@ -292,7 +292,7 @@ def run_ddc(adc_samples):
         # adc_signed_w = {1'b0, adc_data, 9'b0} - {1'b0, 8'hFF, 9'b0}/2
         # Simplified: center around zero, scale to 18-bit
         adc_val = int(adc_samples[n])
-        adc_signed = (adc_val - 128) << 9  # Approximate RTL sign conversion to 18-bit
+        adc_signed = (adc_val << 9) - 0xFF00  # Exact RTL: {1'b0,adc,9'b0} - {1'b0,8'hFF,9'b0}/2
         adc_signed = saturate(adc_signed, 18)
         
         # NCO lookup (ignoring dithering for golden reference)

--- a/9_Firmware/9_3_GUI/GUI_V6.py
+++ b/9_Firmware/9_3_GUI/GUI_V6.py
@@ -1734,9 +1734,9 @@ class RadarGUI:
         """Step 39: Process incoming radar data from FTDI"""
         buffer = b''
         while True:
-            if self.running and self.ftdi_interface.is_open:
+            if self.running and self.ft601_interface.is_open:
                 try:
-                    data = self.ftdi_interface.read_data(4096)
+                    data = self.ft601_interface.read_data(4096)
                     if data:
                         buffer += data
                         

--- a/9_Firmware/tests/cross_layer/contract_parser.py
+++ b/9_Firmware/tests/cross_layer/contract_parser.py
@@ -494,9 +494,10 @@ def count_concat_bits(concat_expr: str, port_widths: dict[str, int]) -> ConcatWi
             fragments.append((part, w))
             total += w
         else:
-            # Unknown width — flag it
+            # Unknown width — flag it and stop accumulating
             fragments.append((part, -1))
             total = -1  # Can't compute
+            break
 
     return ConcatWidth(
         total_bits=total,

--- a/9_Firmware/tests/cross_layer/test_cross_layer_contract.py
+++ b/9_Firmware/tests/cross_layer/test_cross_layer_contract.py
@@ -49,8 +49,8 @@ sys.path.insert(0, str(cp.GUI_DIR))
 # Helpers
 # ===================================================================
 
-IVERILOG = os.environ.get("IVERILOG", "/opt/homebrew/bin/iverilog")
-VVP = os.environ.get("VVP", "/opt/homebrew/bin/vvp")
+IVERILOG = os.environ.get("IVERILOG", "iverilog")
+VVP = os.environ.get("VVP", "vvp")
 CXX = os.environ.get("CXX", "c++")
 
 # Check tool availability for conditional skipping


### PR DESCRIPTION
## Summary

Four independent bug fixes found during a review of the v1.1.0-agc release. All changes are in the Python/CI layer and require no FPGA rebuild or hardware testing.

## Changes

### 1. fix(ci): use PATH-based iverilog/vvp discovery

**File:** `9_Firmware/tests/cross_layer/test_cross_layer_contract.py` (lines 52–53)

**Problem:** The default `IVERILOG` and `VVP` paths were hardcoded to `/opt/homebrew/bin/iverilog` and `/opt/homebrew/bin/vvp` (macOS Homebrew-specific). On Ubuntu CI runners, `apt-get install iverilog` places the binary at `/usr/bin/iverilog`. Since the default path contains `/`, the `_has_iverilog` check at line 57 does a `Path.exists()` check on the literal path — which returns `False` on Ubuntu. All Tier 2 Verilog cosimulation tests are then silently skipped via `@pytest.mark.skipif(not _has_iverilog)`.

The CI workflow (`ci-tests.yml:110`) installs iverilog but never sets the `IVERILOG` environment variable, so the fallback always applies.

**Fix:** Change defaults from absolute macOS paths to bare command names (`"iverilog"`, `"vvp"`), which triggers PATH-based `which` discovery at line 57–58. This works on both macOS (Homebrew adds to PATH) and Ubuntu CI (apt installs to `/usr/bin/`).

**Verification:** On this machine, `which iverilog` correctly resolves regardless of the absolute path. On Ubuntu CI, the change enables `_has_iverilog = True`, causing Tier 2 tests to run instead of skip.

### 2. fix(cosim): align golden_reference ADC formula with RTL

**File:** `9_Firmware/9_2_FPGA/tb/cosim/real_data/golden_reference.py` (line 295)

**Problem:** The golden reference used `(adc_val - 128) << 9` for ADC sign conversion, which subtracts `65536`. The actual RTL in `ddc_400m.v:228–229` computes `{1'b0, adc_data, 9'b0} - {1'b0, 8'hFF, 9'b0}/2`, which subtracts `0xFF00 = 65280`. This creates a constant 256-LSB DC offset between the golden reference and RTL for all 256 ADC input values.

The bit-accurate model in `fpga_model.py:298–307` already uses the correct RTL formula. Only `golden_reference.py` was inconsistent.

**Fix:** Change to `(adc_val << 9) - 0xFF00` to match the exact Verilog expression.

**Verification:** Tested all 256 ADC values — the fix produces zero offset against `fpga_model.py` for every input.

### 3. fix(gui): correct attribute name in GUI_V6 radar data thread

**File:** `9_Firmware/9_3_GUI/GUI_V6.py` (line 1737, 1739)

**Problem:** `process_radar_data()` references `self.ftdi_interface.is_open` and `self.ftdi_interface.read_data()`, but the class `__init__` (line 1052) creates `self.ft601_interface` — the old name was left over from before the FT601 refactor. This causes `AttributeError` when the radar data thread starts.

**Fix:** Replace `self.ftdi_interface` with `self.ft601_interface` on lines 1737 and 1739.

**Verification:** `grep -n 'self.ftdi_interface' GUI_V6.py` returns zero matches after the fix. `self.ft601_interface` is initialized at line 1052.

### 4. fix(test): break on unknown signal in count_concat_bits

**File:** `9_Firmware/tests/cross_layer/contract_parser.py` (line 499)

**Problem:** When `count_concat_bits` encounters an unknown signal, it sets `total = -1` but does **not** break out of the loop. Subsequent known signals add their widths to -1, producing incorrect totals (e.g., `-1 + 16 = 15` instead of `-1`). This can cause `ConcatWidth.truncated` to report `False` when truncation status is genuinely unknown.

**Fix:** Add `break` after `total = -1` so the function immediately returns with an unresolvable total.

**Verification:** Tested three scenarios — `{unknown, known_16bit}` now correctly returns `total=-1` instead of `15`.

## Test Plan

- [ ] `cross-layer-tests` CI job: Tier 2 tests execute (not silently skipped) on Ubuntu runner
- [ ] `python3 -c "print((128 << 9) - 0xFF00)"` outputs `256` (not `0`), confirming the RTL-accurate midscale value
- [ ] `grep 'ftdi_interface' 9_Firmware/9_3_GUI/GUI_V6.py` returns no matches
- [ ] Existing CI tests continue to pass (no behavioral change for known signals in concat parser)

## Related Issues

- #82 (AGC gain arithmetic overflow — separate RTL fix, needs Vivado rebuild)
- #83 (volatile + holdoff_frames — separate MCU fix, needs hardware validation)