### PR TITLE
fix(ci): use PATH-based iverilog/vvp discovery for cross-layer tests

### DIFF
--- a/9_Firmware/tests/cross_layer/test_cross_layer_contract.py
+++ b/9_Firmware/tests/cross_layer/test_cross_layer_contract.py
@@ -61,6 +61,20 @@ _has_cxx = subprocess.run(
     [CXX, "--version"], capture_output=True
 ).returncode == 0
 
+# In CI, missing tools must be a hard failure — never silently skip.
+_in_ci = os.environ.get("GITHUB_ACTIONS") == "true"
+if _in_ci:
+    if not _has_iverilog:
+        raise RuntimeError(
+            "iverilog is required in CI but was not found. "
+            "Ensure 'apt-get install iverilog' ran and IVERILOG/VVP are on PATH."
+        )
+    if not _has_cxx:
+        raise RuntimeError(
+            "C++ compiler is required in CI but was not found. "
+            "Ensure build-essential is installed."
+        )
+
 
 def _parse_hex_results(text: str) -> list[dict[str, str]]:
     """Parse space-separated hex lines from TB output files."""

--- a/9_Firmware/tests/cross_layer/test_cross_layer_contract.py
+++ b/9_Firmware/tests/cross_layer/test_cross_layer_contract.py
@@ -49,8 +49,8 @@ sys.path.insert(0, str(cp.GUI_DIR))
 # Helpers
 # ===================================================================
 
-IVERILOG = os.environ.get("IVERILOG", "/opt/homebrew/bin/iverilog")
-VVP = os.environ.get("VVP", "/opt/homebrew/bin/vvp")
+IVERILOG = os.environ.get("IVERILOG", "iverilog")
+VVP = os.environ.get("VVP", "vvp")
 CXX = os.environ.get("CXX", "c++")
 
 # Check tool availability for conditional skipping


### PR DESCRIPTION
## Summary

All Tier 2 Verilog cosimulation tests in `cross-layer-tests` CI job are silently skipped on Ubuntu runners because the default iverilog path points to a macOS-only location.

## Root Cause

`test_cross_layer_contract.py` lines 52–53 default to:

```python
IVERILOG = os.environ.get("IVERILOG", "/opt/homebrew/bin/iverilog")
VVP = os.environ.get("VVP", "/opt/homebrew/bin/vvp")
```

The `_has_iverilog` check at line 57 does `Path(IVERILOG).exists()` when the path contains `/`. On Ubuntu CI, `apt-get install iverilog` puts the binary at `/usr/bin/iverilog`, so the literal `/opt/homebrew/bin/iverilog` does not exist. The CI workflow (`ci-tests.yml:110`) installs iverilog but never sets the `IVERILOG` environment variable.

Result: `_has_iverilog = False` → `@pytest.mark.skipif(not _has_iverilog)` → all Tier 2 tests silently skip → CI reports green with zero Verilog round-trip coverage.

## Fix

Change defaults to bare command names (`"iverilog"`, `"vvp"`). Since these don't contain `/`, the existing fallback at line 57–58 uses `which` to discover the binary via PATH — which works on both macOS (Homebrew adds to PATH) and Ubuntu (`/usr/bin/` is in PATH).

## Verification

Confirmed that after this change:
- macOS with Homebrew: `which iverilog` resolves to `/opt/homebrew/bin/iverilog` ✓
- Ubuntu CI: `which iverilog` resolves to `/usr/bin/iverilog` ✓
- `IVERILOG` env var override still works for custom installations ✓

## Test Plan

- [ ] `cross-layer-tests` CI job: Tier 2 tests now execute (not silently skipped)
- [ ] Existing Tier 1 and Tier 3 tests unaffected