### PR TITLE
fix(cosim): align golden_reference ADC sign conversion with RTL

### DIFF
--- a/9_Firmware/9_2_FPGA/tb/cosim/fpga_model.py
+++ b/9_Firmware/9_2_FPGA/tb/cosim/fpga_model.py
@@ -291,9 +291,12 @@ class Mixer:
         Convert 8-bit unsigned ADC to 18-bit signed.
         RTL: adc_signed_w = {1'b0, adc_data, {9{1'b0}}} -
                             {1'b0, {8{1'b1}}, {9{1'b0}}} / 2
-        = (adc_data << 9) - (0xFF << 9) / 2
-        = (adc_data << 9) - (0xFF << 8)  [integer division]
-        = (adc_data << 9) - 0x7F80
+
+        Verilog '/' binds tighter than '-', so the division applies
+        only to the second concatenation:
+            {1'b0, 8'hFF, 9'b0} = 0x1FE00
+            0x1FE00 / 2 = 0xFF00 = 65280
+        Result: (adc_data << 9) - 0xFF00
         """
         adc_data_8bit = adc_data_8bit & 0xFF
         # {1'b0, adc_data, 9'b0} = adc_data << 9, zero-padded to 18 bits

--- a/9_Firmware/9_2_FPGA/tb/cosim/real_data/golden_reference.py
+++ b/9_Firmware/9_2_FPGA/tb/cosim/real_data/golden_reference.py
@@ -292,7 +292,7 @@ def run_ddc(adc_samples):
         # adc_signed_w = {1'b0, adc_data, 9'b0} - {1'b0, 8'hFF, 9'b0}/2
         # Simplified: center around zero, scale to 18-bit
         adc_val = int(adc_samples[n])
-        adc_signed = (adc_val - 128) << 9  # Approximate RTL sign conversion to 18-bit
+        adc_signed = (adc_val << 9) - 0xFF00  # Exact RTL: {1'b0,adc,9'b0} - {1'b0,8'hFF,9'b0}/2
         adc_signed = saturate(adc_signed, 18)
         
         # NCO lookup (ignoring dithering for golden reference)

--- a/9_Firmware/9_2_FPGA/tb/cosim/real_data/golden_reference.py
+++ b/9_Firmware/9_2_FPGA/tb/cosim/real_data/golden_reference.py
@@ -290,7 +290,7 @@ def run_ddc(adc_samples):
     for n in range(n_samples):
         # ADC sign conversion: RTL does offset binary → signed 18-bit
         # adc_signed_w = {1'b0, adc_data, 9'b0} - {1'b0, 8'hFF, 9'b0}/2
-        # Simplified: center around zero, scale to 18-bit
+        # Exact: (adc_val << 9) - 0xFF00, where 0xFF00 = {1'b0,8'hFF,9'b0}/2
         adc_val = int(adc_samples[n])
         adc_signed = (adc_val << 9) - 0xFF00  # Exact RTL: {1'b0,adc,9'b0} - {1'b0,8'hFF,9'b0}/2
         adc_signed = saturate(adc_signed, 18)


### PR DESCRIPTION
## Summary

The ADC sign conversion formula in `golden_reference.py` does not match the actual RTL in `ddc_400m.v`, producing a constant 256-LSB DC offset for all 256 ADC input values.

## Root Cause

The golden reference (line 295) uses:

```python
adc_signed = (adc_val - 128) << 9  # subtracts 128 * 512 = 65536
```

The RTL in `ddc_400m.v:228–229` computes:

```verilog
assign adc_signed_w = {1'b0, adc_data, 9'b0} - {1'b0, 8'hFF, 9'b0} / 2;
//                                                 = 0x1FE00 / 2 = 0xFF00 = 65280
```

The division `/2` in Verilog binds to the second operand only (higher precedence than `-`), so the RTL subtracts 65280, not 65536. The difference is a constant 256-LSB DC offset.

The bit-accurate model in `fpga_model.py:298–307` already uses the correct formula `(adc_data << 9) - 0xFF00`. Only `golden_reference.py` was inconsistent.

## Verification

Tested all 256 ADC input values:
- **Before fix**: every value shows `fpga_model - golden_ref = +256` (constant offset)
- **After fix**: every value shows `fpga_model - golden_ref = 0` (exact match)

```python
# Before: golden_ref(128) = 0, fpga_model(128) = 256 → mismatch
# After:  golden_ref(128) = 256, fpga_model(128) = 256 → match
```

## Test Plan

- [ ] Existing cosim golden reference tests continue to pass
- [ ] `python3 -c "print((128 << 9) - 0xFF00)"` outputs `256` (RTL mid-scale value)