### PR TITLE
fix(gui): correct stale attribute name in GUI_V6 radar data thread

### DIFF
--- a/9_Firmware/9_3_GUI/GUI_V6.py
+++ b/9_Firmware/9_3_GUI/GUI_V6.py
@@ -1734,9 +1734,9 @@ class RadarGUI:
         """Step 39: Process incoming radar data from FTDI"""
         buffer = b''
         while True:
-            if self.running and self.ftdi_interface.is_open:
+            if self.running and self.ft601_interface.is_open:
                 try:
-                    data = self.ftdi_interface.read_data(4096)
+                    data = self.ft601_interface.read_data(4096)
                     if data:
                         buffer += data
                         


### PR DESCRIPTION
## Summary

`GUI_V6.py` crashes with `AttributeError` when the radar data thread starts because `process_radar_data()` references an attribute name from before the FT601 refactor.

## Root Cause

The class `__init__` at line 1052 creates:

```python
self.ft601_interface = FT601Interface()  # Changed from FTDIInterface
```

But `process_radar_data()` at lines 1737 and 1739 still references the old name:

```python
if self.running and self.ftdi_interface.is_open:       # line 1737
    data = self.ftdi_interface.read_data(4096)          # line 1739
```

`self.ftdi_interface` is never assigned anywhere in the class, so this raises `AttributeError` on the first iteration of the radar data thread.

## Fix

Replace `self.ftdi_interface` with `self.ft601_interface` on lines 1737 and 1739.

## Verification

```bash
# Before fix:
grep -n 'self.ftdi_interface' GUI_V6.py
# 1737, 1739 — references undefined attribute

# After fix:
grep -n 'self.ftdi_interface' GUI_V6.py
# (no output — all references corrected)
```

## Test Plan

- [ ] `grep 'ftdi_interface' GUI_V6.py` returns no matches
- [ ] GUI_V6.py can be imported without errors: `python3 -c "import GUI_V6"`