### PR TITLE
fix(test): break on unknown signal in count_concat_bits

### DIFF
--- a/9_Firmware/tests/cross_layer/contract_parser.py
+++ b/9_Firmware/tests/cross_layer/contract_parser.py
@@ -497,6 +497,7 @@ def count_concat_bits(concat_expr: str, port_widths: dict[str, int]) -> ConcatWi
             # Unknown width — flag it
             fragments.append((part, -1))
             total = -1  # Can't compute
+            break
 
     return ConcatWidth(
         total_bits=total,


### PR DESCRIPTION
## Summary

`count_concat_bits()` in `contract_parser.py` produces incorrect bit totals when an unknown signal appears before known signals in a Verilog concatenation.

## Root Cause

When an unknown signal is encountered (line 498–499):

```python
fragments.append((part, -1))
total = -1  # Can't compute
```

The loop **does not break**. On the next iteration, if the signal is known (e.g., 16-bit `status_cfar_threshold`), its width is added: `total += 16` → `-1 + 16 = 15`. The final `ConcatWidth` then reports `total_bits=15` and `truncated=False`, when the correct answer is `total_bits=-1` (unknown).

This can mask genuine truncation bugs — if one field in a status word concatenation has an unknown width, the truncation check should be "unknown", not "definitely safe".

## Verification

Three test scenarios confirmed:

```python
# {unknown_signal, known_16bit}
# Before: total = -1 + 16 = 15 (wrong — looks like "fits in 32 bits")
# After:  total = -1 (correct — "unknown, cannot verify")

# {sig_a_8bit, unknown_sig, sig_c_16bit}
# Before: total = 8 + (-1) + 16 = ... total set to -1 then +16 = 15
# After:  total = -1 (breaks at unknown)

# {unknown_sig, 8'hFF}
# Before: total = -1 + 8 = 7
# After:  total = -1
```

## Fix

Add `break` after `total = -1` so the function immediately stops accumulating and returns an unresolvable total.

## Test Plan

- [ ] Existing cross-layer contract tests continue to pass (no known signals are affected)
- [ ] Concatenations with all known signals produce unchanged results