### PR TITLE
Update openems_quartz_slotted_wg_10p5GHz.py

### DIFF
--- a/5_Simulations/Antenna/openems_quartz_slotted_wg_10p5GHz.py
+++ b/5_Simulations/Antenna/openems_quartz_slotted_wg_10p5GHz.py
@@ -84,8 +84,8 @@ margin = 0.25*lambda_g_mm
 # ===================================
 # FDTD / CSX / MESH (explicit lines)
 # ===================================
-unit_mm = 1e-3
-Sim_Path = os.path.join(tempfile.gettempdir(), f'openems_quartz_slotted_wg_{PROFILE}')
+unit_mm = 1e-3  # mm → m
+Sim_Path = os.path.join(tempfile.gettempdir(), f'openems_wg_{PROFILE}')  # temp sim path
 
 FDTD = openEMS(NrTS=int(6e5), EndCriteria=1e-5)
 FDTD.SetGaussExcite(0.5*(f_start+f_stop), 0.5*(f_stop-f_start))


### PR DESCRIPTION
# Conversion factor from millimeters to meters.
# Used to ensure all geometric dimensions are defined in SI units (meters) # for consistency with the simulation solver.
# Defines the file system path for storing simulation data. # Uses the system's temporary directory to avoid manual cleanup. # The path is dynamically named based on the PROFILE to keep runs organized # and prevent conflicts between different simulation configurations.