### PR TITLE
docs(readme): correct STM32 peripheral counts and locations to match production BOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,13 @@ The AERIS-10 main sub-systems are:
       - Clock Generator (AD9523-1)
       - 2x Frequency Synthesizers (ADF4382)
       - 4x 4-Channel Phase Shifters (ADAR1000) for RADAR pulse sequencing
-      - 2x ADS7830 ADCs (on Power Amplifier Boards) for Idq measurement
-      - 2x DAC5578 (on Power Amplifier Boards) for Vg control
-      - GPS module for GUI map centering
+      - 2x ADS7830 8-channel I²C ADCs (Main Board, U88 @ 0x48 / U89 @ 0x4A) for 16x Idq measurement, one per PA channel, each sensed through a 5 mΩ shunt on the PA board and an INA241A3 current-sense amplifier (x50) on the Main Board
+      - 2x DAC5578 8-channel I²C DACs (Main Board, U7 @ 0x48 / U69 @ 0x49) for 16x Vg control, one per PA channel; closed-loop calibrated at boot to the target Idq
+      - GPS module (UM982) for GUI map centering and per-detection position tagging
       - GY-85 IMU for pitch/roll correction of target coordinates
       - BMP180 Barometer
       - Stepper Motor
-      - 8x ADS7830 Temperature Sensors for cooling fan control
+      - 1x ADS7830 8-channel I²C ADC (Main Board, U10) reading 8 thermistors for thermal monitoring; a single GPIO (EN_DIS_COOLING) switches the cooling fans on when any channel exceeds the threshold
       - RF switches
 
 - **16x Power Amplifier Boards** - Used only for AERIS-10E version, featuring 10Watt QPA2962 GaN amplifier for extended range


### PR DESCRIPTION
## Summary

The STM32 peripheral list in the README disagreed with the production BOM (`4_7_Production Files/Gerber_Main_Board/RADAR_Main_Board_BOM_csv`, tip of `origin/main` at 754d919) and with the firmware in `9_Firmware/9_1_Microcontroller/9_1_3_C_Cpp_Code/main.cpp`. This PR aligns the README with what is actually populated on the boards.

## Corrections

| Item | Old README | Correct (per BOM + firmware) |
|---|---|---|
| Idq ADCs | "2x ADS7830 **on Power Amplifier Boards**" | 2x ADS7830 **on the Main Board** (U88 @ 0x48, U89 @ 0x4A); sensed via 5 mΩ shunt on PA board + INA241A3 x50 current-sense amp on Main Board |
| Vg DACs | "2x DAC5578 **on Power Amplifier Boards**" | 2x DAC5578 **on the Main Board** (U7 @ 0x48, U69 @ 0x49); closed-loop Idq calibration at boot |
| Temperature | "**8x** ADS7830 Temperature Sensors" | **1x** ADS7830 (U10) with 8 single-ended channels reading 8 thermistors |
| Cooling | "for cooling fan control" | Single GPIO (`EN_DIS_COOLING`), bang-bang on/off — not PWM |
| GPS | "for GUI map centering" | UM982 (driver merged in #79); also used for per-detection position tagging |

## Evidence

- BOM: `git show origin/main:"4_Schematics and Boards Layout/4_7_Production Files/Gerber_Main_Board/RADAR_Main_Board_BOM_csv"` → `3x ADS7830IPWR` (U10, U88, U89), `2x DAC5578SRGET` (U7, U69), `16x INA241A3` (U11, U73–U87).
- Firmware: `main.cpp` declares `ADS7830_HandleTypeDef hadc1, hadc2, hadc3` (matches 3 chips), `DAC5578_HandleTypeDef hdac1, hdac2` (matches 2 chips), and uses a single `EN_DIS_COOLING` GPIO for fan control (no PWM).

## Non-goals

This PR does **not** touch the BOM, schematic, or firmware. Documentation-only change.