### PR TITLE
test(cross-layer): enforce status word field positions match Verilog concat layout

### DIFF
--- a/9_Firmware/tests/cross_layer/test_cross_layer_contract.py
+++ b/9_Firmware/tests/cross_layer/test_cross_layer_contract.py
@@ -314,6 +314,68 @@ class TestTier1StatusFieldPositions:
             f"but Verilog status_words[0] has mode at bit {expected_shift}."
         )
 
+    @pytest.mark.parametrize(
+        "usb_variant",
+        ["usb_data_interface_ft2232h.v", "usb_data_interface.v"],
+    )
+    def test_status_field_positions_match_verilog_concat_layout(self, usb_variant):
+        """
+        Independent static check: every Python field in parse_status_packet()
+        must sit at the (word_idx, lsb, width) where Verilog places it inside
+        status_words[0..5]. Walks each Verilog concat MSB->LSB and compares to
+        what the Python parser extracts. Exercised across both USB variants
+        because both are live post PR #89.
+        """
+        rtl_path = cp.FPGA_DIR / usb_variant
+        if not rtl_path.exists():
+            pytest.skip(f"{usb_variant} not present")
+
+        concats = cp.parse_verilog_status_word_concats(rtl_path)
+        port_widths = cp.get_usb_interface_port_widths(rtl_path)
+
+        # Build verilog_layout: signal_name -> (word_idx, lsb, width)
+        verilog_layout: dict[str, tuple[int, int, int]] = {}
+        literal_re = re.compile(r"^\d+'[bdhoBDHO]")
+        for word_idx, concat_expr in concats.items():
+            result = cp.count_concat_bits(concat_expr, port_widths)
+            # Skip malformed words; total-width assertion belongs to
+            # TestTier1StatusWordTruncation, not this test.
+            if result.total_bits != 32:
+                continue
+            running_lsb = result.total_bits  # MSB-first walk
+            for name_or_literal, width in result.fragments:
+                running_lsb -= width
+                if literal_re.match(name_or_literal):
+                    continue
+                verilog_layout[name_or_literal] = (word_idx, running_lsb, width)
+
+        py_fields = cp.parse_python_status_fields()
+
+        mismatches: list[str] = []
+        for f in py_fields:
+            v_name = f"status_{f.name}"
+            v_pos = verilog_layout.get(v_name)
+            if v_pos is None:
+                mismatches.append(
+                    f"  {f.name}: py=(word={f.word_index}, lsb={f.lsb}, "
+                    f"width={f.width})  v=<no '{v_name}' fragment in Verilog>"
+                )
+                continue
+            v_word, v_lsb, v_width = v_pos
+            if (v_word, v_lsb, v_width) != (f.word_index, f.lsb, f.width):
+                mismatches.append(
+                    f"  {f.name}: py=(word={f.word_index}, lsb={f.lsb}, "
+                    f"width={f.width})  v=(word={v_word}, lsb={v_lsb}, "
+                    f"width={v_width})"
+                )
+
+        if mismatches:
+            pytest.fail(
+                f"Status field layout drift between Python parse_status_packet() "
+                f"and Verilog status_words[] in {usb_variant}:\n"
+                + "\n".join(mismatches)
+            )
+
 
 class TestTier1PacketConstants:
     """Verify packet header/footer/size constants match across layers."""


### PR DESCRIPTION
## Summary
Adds one independent Tier-1 static check to `TestTier1StatusFieldPositions` that asserts every Python field extracted by `parse_status_packet()` sits at the `(word_idx, lsb, width)` where Verilog places it in the `status_words[0..5]` concatenation, across both FT2232H and FT601 USB variants.

## Why this is not redundant with Tier-2 round-trip
The file docstring at `test_cross_layer_contract.py:22-24` requires independently-derived ground truth rather than confirming that two layers agree (because both could be wrong together). The existing Tier-2 `test_status_packet_python_round_trip` passes a stimulus through the Verilog TB and parses the output with `RadarProtocol.parse_status_packet()` — the same code used in production — so a coupled Verilog+Python bit-position shift passes Tier-2 silently. The TB only independently validates raw bytes for `status_words[1]`/`[2]`; `[0]`, `[3]`, `[4]`, `[5]` have no independent check today.

## What the new test does
Walks each Verilog `status_words[N]` concatenation MSB→LSB via `count_concat_bits`, computes the bit position of every named payload fragment, drops literal padding, and compares `(word_idx, lsb, width)` against each field `parse_status_packet` extracts. Name matching is `status_<python_name>` on the Verilog side (current convention has zero exceptions). Accumulates all mismatches into a single failure message so one run surfaces every drift at once.

## Test plan
- [x] `uv run pytest 9_Firmware/tests/cross_layer/test_cross_layer_contract.py::TestTier1StatusFieldPositions -v` — both parametrized invocations pass.
- [x] `uv run pytest 9_Firmware/tests/cross_layer/test_cross_layer_contract.py -q` — suite stays green (38 passed, was 36).
- [x] Local negative check: shifted `agc_enable` mask by one bit → both parametrized invocations fail with `agc_enable: py=(word=4, lsb=10, width=1)  v=(word=4, lsb=11, width=1)`; reverted → green again.

## Scope boundaries
- Test-file only, zero RTL/MCU changes.
- Does not touch the existing `test_python_status_mode_position` (the single per-field check already there).
- Reset-default completeness is a separate follow-up that first needs an explicit `PULSE_REGS` set — not bundled here.