### PR TITLE
docs(contributing): add AI usage policy section (from #106)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,14 @@ Never run bare package installation commands without the `sfw` prefix.
 - **System-Level Invariants**:
   - Whenever adding code, verify that system-level invariants (across module, process, and chip boundaries) hold true.
 
+## AI Usage Policy
+
+The use of AI is permitted but we have to make sure that the quality and control of the codebase doesn't depend on the agents but the maintainer pushing the changes, meaning they are fully responsible for the code they commit.
+
+1. **Human Accountability** — The committing engineer is fully responsible for AI-generated code as if they wrote it. Every PR must be understood and defensible by a human.
+2. **Mandatory Review** — No raw AI output may be committed unread. AI code must pass the same review bar as hand-written code.
+3. **Full CI Before Commit** — All AI-assisted changes must pass the complete CI suite locally (lint, unit, regression, cross-layer) before commit.
+
 ## Running the Test Suites
 
 We use GitHub Actions for CI, which runs four main jobs on every PR. Run these locally before pushing.


### PR DESCRIPTION
## Summary

Surfaces the AI Usage Policy articulated in #106 in the project's onboarding doc so it's discoverable by contributors before their first PR. Opens at your invitation in https://github.com/NawfalMotii79/PLFM_RADAR/issues/106#issuecomment-4273144522.

## Changes

- Adds a new `## AI Usage Policy` section to `CONTRIBUTING.md` between `## Code Standards & Tooling` and `## Running the Test Suites`.
- Section body is the #106 comment verbatim with two small typo fixes only (`use if AI` → `use of AI`, `doesnt` → `doesn't`). Structure, wording, numbering, and emphasis preserved.

## Scope boundaries

- Doc only; no code, config, test, or workflow changes.
- No rewording beyond the two typo fixes.

## Test plan

- [x] `git diff --check` — no whitespace issues
- [x] `uv run ruff check 9_Firmware` — clean (markdown is out of ruff scope; project Python passes)
- [x] Manual preview of the rendered section — reads cleanly between the two existing sections

Closes discussion in #106.