### PR TITLE
fix(fpga): widen AGC gain arithmetic to 6-bit to prevent wraparound

### DIFF
--- a/9_Firmware/9_2_FPGA/rx_gain_control.v
+++ b/9_Firmware/9_2_FPGA/rx_gain_control.v
@@ -169,11 +169,11 @@ endfunction
 // =========================================================================
 // Clamp a wider signed value to [-7, +7]
 function signed [3:0] clamp_gain;
-    input signed [4:0] val;  // 5-bit to handle overflow from add
+    input signed [5:0] val;  // 6-bit: covers [-22,+22] (max |gain|+step = 7+15)
     begin
-        if (val > 5'sd7)
+        if (val > 6'sd7)
             clamp_gain = 4'sd7;
-        else if (val < -5'sd7)
+        else if (val < -6'sd7)
             clamp_gain = -4'sd7;
         else
             clamp_gain = val[3:0];
@@ -246,15 +246,15 @@ always @(posedge clk or negedge reset_n) begin
                 // Use inclusive counts/peaks (accounting for simultaneous valid_in)
                 if (wire_frame_sat_incr || frame_sat_count > 8'd0) begin
                     // Clipping detected: reduce gain immediately (attack)
-                    agc_gain <= clamp_gain($signed({agc_gain[3], agc_gain}) -
-                                           $signed({1'b0, agc_attack}));
+                    agc_gain <= clamp_gain($signed({agc_gain[3], agc_gain[3], agc_gain}) -
+                                           $signed({2'b00, agc_attack}));
                     holdoff_counter <= agc_holdoff;  // Reset holdoff
                 end else if ((wire_frame_peak_update ? max_iq[14:7] : frame_peak[14:7])
                              < agc_target) begin
                     // Signal too weak: increase gain after holdoff expires
                     if (holdoff_counter == 4'd0) begin
-                        agc_gain <= clamp_gain($signed({agc_gain[3], agc_gain}) +
-                                               $signed({1'b0, agc_decay}));
+                        agc_gain <= clamp_gain($signed({agc_gain[3], agc_gain[3], agc_gain}) +
+                                               $signed({2'b00, agc_decay}));
                     end else begin
                         holdoff_counter <= holdoff_counter - 4'd1;
                     end


### PR DESCRIPTION
## Issue

5-bit signed arithmetic in `clamp_gain` wraps for `agc_attack >= 10` or `agc_decay >= 9` when `|agc_gain| + step > 16`, inverting gain polarity instead of clamping to the intended bound.

Example: `agc_gain = -7`, `agc_attack = 10` → mathematical result is -17, but 5-bit signed wraps to +15 → `clamp_gain` returns **+7** (max amplification) instead of **-7** (max attenuation). This is a full 14-step polarity inversion that causes sustained ADC saturation on strong-signal returns.

- **Attack path**: 21/240 gain × attack combinations produce incorrect results
- **Decay path**: 28/240 combinations produce incorrect results
- **Every failure flips gain polarity**

Introduced in commit `ffba27a` (PR #59/#67). Does not trigger with default `agc_attack`/`agc_decay` values of 1–4, only when configured to ≥ 10/9 respectively.

Related fix `b4d1869` (PR sign-ext & snapshot) corrected zero-extension of `agc_gain` itself but did not address the arithmetic width — this PR addresses the remaining root cause.

## Fix

Widen `clamp_gain` input from `[4:0]` to `[5:0]` (6-bit signed, covering `[-22, +22]` = max `|gain| + step` of `7 + 15`), and sign-extend both operands to 6 bits at each call site:

```verilog
// Before (5-bit — wraps when |gain| + step > 16)
clamp_gain($signed({agc_gain[3], agc_gain}) - $signed({1'b0, agc_attack}))

// After (6-bit — covers full [-22,+22] range before clamping)
clamp_gain($signed({agc_gain[3], agc_gain[3], agc_gain}) - $signed({2'b00, agc_attack}))
```

Both the attack (line 249) and decay (line 256) paths are updated.

## Impact

- **Default configuration (attack/decay 1–4):** zero behavioural change
- **High attack/decay (≥ 10/9):** gain now monotonically clamps to ±7 as expected, eliminating polarity inversion and false saturation signals to the MCU outer AGC loop
- No downstream contract breaks — testbench assertions, MCU outer loop, Python simulation, and protocol layer all assumed correct clamping; this fix satisfies that assumption

## Testing

Existing FPGA testbench (25 tests / 68 checks) passes unchanged. The wraparound cases (`gain = -7, attack >= 10`) are not currently covered; a follow-up test vector should be added to `tb_rx_gain_control.v` to lock this in.