### PR TITLE
fix(smoke-test): decode self-test results from dedicated status fields

### DIFF
--- a/9_Firmware/9_3_GUI/smoke_test.py
+++ b/9_Firmware/9_3_GUI/smoke_test.py
@@ -148,11 +148,11 @@ class SmokeTest:
                 if ptype == "status":
                     status = RadarProtocol.parse_status_packet(raw[start:end])
                     if status is not None:
-                        # Self-test results encoded in status fields
-                        # (This is a simplification — in production, the FPGA
-                        #  would have a dedicated self-test result packet type)
-                        result_flags = status.cfar_threshold & 0x1F
-                        result_detail = (status.cfar_threshold >> 8) & 0xFF
+                        # Self-test results live in dedicated status fields
+                        # (word 5: self_test_flags[4:0], self_test_detail[7:0]).
+                        # See radar_protocol.py:257 and test_GUI_V65_Tk.py:198.
+                        result_flags = status.self_test_flags
+                        result_detail = status.self_test_detail
                         return (result_flags, result_detail)
 
             time.sleep(0.1)


### PR DESCRIPTION
## Summary

- **Bug:** `smoke_test.py:154-155` extracted self-test flags/detail from `status.cfar_threshold` — but that field carries the CFAR detection threshold (opcode 0x03 readback, `radar_protocol.py:238`), not self-test results.
- **Fix:** Use `status.self_test_flags` / `status.self_test_detail`, which `RadarProtocol.parse_status_packet` already exposes from status word 5 (`radar_protocol.py:257`).
- **Scope:** 5 lines changed in one file. Stale "simplification" comment (predating the dedicated status fields) replaced with current field references.

## Why this is a real bug

On live hardware, `smoke_test.py --live` would have decoded bits from the CFAR detection threshold register as per-subsystem PASS/FAIL flags for the bring-up self-test (BRAM / CIC / FFT / saturating-add / ADC capture). Exit code and on-screen report would be meaningless noise.

The dedicated status fields already exist and are pinned by `test_GUI_V65_Tk.py:198` (`test_parse_status_self_test_all_pass`, `test_parse_status_self_test_busy`) as the contract — `smoke_test.py` had not caught up to the schema change.

## Test plan

- [x] `uv run pytest 9_Firmware/9_3_GUI/test_GUI_V65_Tk.py -q -k self_test` — 8 passed (existing self-test parsing invariants still hold)
- [x] `uv run pytest 9_Firmware/9_3_GUI/test_v7.py 9_Firmware/tests/cross_layer/test_cross_layer_contract.py -q` — 137 passed, 3 skipped (no regression)
- [x] `uv run ruff check 9_Firmware/9_3_GUI/smoke_test.py` — clean
- [x] Module imports correctly from `9_Firmware/9_3_GUI/`