### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,11 +1,9 @@
 name: AERIS-10 CI
-
 on:
   pull_request:
     branches: [main, develop]
   push:
     branches: [main, develop]
-
 jobs:
   # ===========================================================================
   # Python: lint (ruff), syntax check (py_compile), unit tests (pytest)
@@ -14,42 +12,33 @@ jobs:
   python-tests:
     name: Python Lint + Tests
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
-
-      - uses: astral-sh/setup-uv@v5
-
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
       - name: Install dependencies
         run: uv sync --group dev
-
       - name: Ruff lint (whole repo)
         run: uv run ruff check .
-
       - name: Syntax check (py_compile)
         run: |
           uv run python - <<'PY'
           import py_compile
           from pathlib import Path
-
           skip = {".git", "__pycache__", ".venv", "venv", "docs"}
           for p in Path(".").rglob("*.py"):
               if skip & set(p.parts):
                   continue
               py_compile.compile(str(p), doraise=True)
           PY
-
       - name: Unit tests
         run: >
           uv run pytest
           9_Firmware/9_3_GUI/test_GUI_V65_Tk.py
           9_Firmware/9_3_GUI/test_v7.py
           -v --tb=short
-
   # ===========================================================================
   # MCU Firmware Unit Tests (20 tests)
   # Bug regression (15) + Gap-3 safety tests (5)
@@ -57,34 +46,26 @@ jobs:
   mcu-tests:
     name: MCU Firmware Tests
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v4
-
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Install build tools
         run: sudo apt-get update && sudo apt-get install -y build-essential
-
       - name: Build and run MCU tests
         run: make test
         working-directory: 9_Firmware/9_1_Microcontroller/tests
-
   # ===========================================================================
   # FPGA RTL Regression (25 testbenches + lint)
   # ===========================================================================
   fpga-regression:
     name: FPGA Regression
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v4
-
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Install Icarus Verilog
         run: sudo apt-get update && sudo apt-get install -y iverilog
-
       - name: Run full FPGA regression
         run: bash run_regression.sh
         working-directory: 9_Firmware/9_2_FPGA
-
   # ===========================================================================
   # Cross-Layer Contract Tests (Python ↔ Verilog ↔ C)
   # Validates opcode maps, bit widths, packet layouts, and round-trip
@@ -93,22 +74,16 @@ jobs:
   cross-layer-tests:
     name: Cross-Layer Contract Tests
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
-
-      - uses: astral-sh/setup-uv@v5
-
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
       - name: Install dependencies
         run: uv sync --group dev
-
       - name: Install Icarus Verilog
         run: sudo apt-get update && sudo apt-get install -y iverilog
-
       - name: Run cross-layer contract tests
         run: >
           uv run pytest


### PR DESCRIPTION
All eight `uses:` lines in `ci-tests.yml` reference actions by mutable
version tags (`@v4`, `@v5`). The tag can move, if any of these action
repos pushed a bad commit to their tag, it'd run here on the next PR
with no change to this repo.

Pinned each to the commit SHA the tag currently points to, with a
`# vN` comment so the version stays readable:

- `actions/checkout@v4`     → `34e114876b0b11c390a56381ad16ebd13914f8d5`
- `actions/setup-python@v5` → `a26af69be951a213d495a4c3e4e4022e16d87065`
- `astral-sh/setup-uv@v5`   → `d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86`

No functional change. To update later, just bump the SHA and the comment together.