### PR TITLE
fix: three utility bugs in compare, LUT, and triangular waveform scripts

### DIFF
--- a/8_Utils/Python/Gen_Triangular.py
+++ b/8_Utils/Python/Gen_Triangular.py
@@ -41,7 +41,7 @@ plt.xlim(0, (fmax+fmax/10))
 plt.ylim(0, 20)
 
 plt.subplot(122)
-plt.plot(2*n, y)
+plt.plot(t, x)
 plt.xlabel('Time (s)')
 plt.ylabel('Amplitude')
 plt.tight_layout()

--- a/8_Utils/Python/LUT.py
+++ b/8_Utils/Python/LUT.py
@@ -21,4 +21,4 @@ y_scaled = np.round(y * 127.5).astype(int)  # Scale to 8-bit range (0-255)
 
 # Print values in Verilog-friendly format
 for _i in range(n):
-    pass
+    print(f"8'd{y_scaled[_i]},")

--- a/9_Firmware/9_2_FPGA/tb/cosim/compare.py
+++ b/9_Firmware/9_2_FPGA/tb/cosim/compare.py
@@ -38,10 +38,11 @@ from fpga_model import SignalChain
 
 # Thresholds for pass/fail
 # These are generous because of LFSR dithering and CDC latency jitter
-MAX_RMS_ERROR_LSB = 50.0     # Max RMS error in 18-bit LSBs
-MIN_CORRELATION = 0.90        # Min Pearson correlation coefficient
-MAX_LATENCY_DRIFT = 15        # Max latency offset between RTL and model (samples)
-MAX_COUNT_DIFF = 20           # Max output count difference (LFSR dithering affects CIC timing)
+MAX_RMS_ERROR_LSB = 50.0       # Max RMS error in 18-bit LSBs
+MAX_ABS_ERROR_LSB = 200.0     # Max absolute error in 18-bit LSBs (4x RMS threshold)
+MIN_CORRELATION = 0.90         # Min Pearson correlation coefficient
+MAX_LATENCY_DRIFT = 15         # Max latency offset between RTL and model (samples)
+MAX_COUNT_DIFF = 20            # Max output count difference (LFSR dithering affects CIC timing)
 
 # Scenarios
 SCENARIOS = {
@@ -314,8 +315,8 @@ def compare_scenario(scenario_name):
     # ---- Error metrics (after alignment) ----
     rms_i = compute_rms_error(aligned_rtl_i, aligned_py_i)
     rms_q = compute_rms_error(aligned_rtl_q, aligned_py_q)
-    compute_max_abs_error(aligned_rtl_i, aligned_py_i)
-    compute_max_abs_error(aligned_rtl_q, aligned_py_q)
+    max_abs_i = compute_max_abs_error(aligned_rtl_i, aligned_py_i)
+    max_abs_q = compute_max_abs_error(aligned_rtl_q, aligned_py_q)
     corr_i_aligned = compute_correlation(aligned_rtl_i, aligned_py_i)
     corr_q_aligned = compute_correlation(aligned_rtl_q, aligned_py_q)
 
@@ -397,6 +398,15 @@ def compare_scenario(scenario_name):
     lag_ok = abs(best_lag) <= MAX_LATENCY_DRIFT
     results.append(('Latency offset', lag_ok,
                      f"|{best_lag}| <= {MAX_LATENCY_DRIFT}"))
+
+    # Check 7: Max absolute error
+    # Catches outlier spikes (pipeline corruption, saturation, CDC glitches)
+    # that RMS and correlation metrics alone can miss.
+    max_abs_err = max(max_abs_i, max_abs_q)
+    max_abs_threshold = cfg.get('max_abs', MAX_ABS_ERROR_LSB)
+    max_abs_ok = max_abs_err <= max_abs_threshold
+    results.append(('Max absolute error', max_abs_ok,
+                     f"max(I={max_abs_i}, Q={max_abs_q}) <= {max_abs_threshold:.0f}"))
 
     # ---- Report ----
     all_pass = True


### PR DESCRIPTION
## Summary

Fix three independent bugs across utility and co-simulation scripts:

1. **compare.py** — `compute_max_abs_error()` return values were silently discarded, so max absolute error was never reported in pass/fail checks. Captures the return values and adds a new Check 7 against a configurable threshold (default 200 LSB, 4x RMS threshold). This catches outlier spikes (pipeline corruption, saturation, CDC glitches) that RMS and correlation metrics alone can miss.

2. **LUT.py** — the loop body was `pass`, producing zero output despite the comment saying "Print values in Verilog-friendly format". Replaced with actual `print(f"8'd{y_scaled[_i]},")` to emit the computed 8-bit values.

3. **Gen_Triangular.py** — `plt.plot(2*n, y)` passed a scalar (`2*n` = 50) as the x-axis against an array `y`, producing a broken plot. Fixed to `plt.plot(t, x)` using the time array `t` and full concatenated signal `x`, matching the correct pattern in sibling file `Generic_Triangular_Frequency.py`.

## Files Changed

- `9_Firmware/9_2_FPGA/tb/cosim/compare.py` — 3 edits (threshold constant, variable capture, pass/fail check)
- `8_Utils/Python/LUT.py` — 1 edit (loop body)
- `8_Utils/Python/Gen_Triangular.py` — 1 edit (plot arguments)

## Note

This replaces #126, which was branched off `main` instead of `develop`, causing a 1.2M-line diff. This branch is cherry-picked cleanly onto `develop` (3 files, 18 insertions, 8 deletions).