### PR TITLE
fix(ci): restore develop CI green — ruff T20 exemption + ADAR1000 setter regex extension

### DIFF
--- a/9_Firmware/tests/cross_layer/test_cross_layer_contract.py
+++ b/9_Firmware/tests/cross_layer/test_cross_layer_contract.py
@@ -768,14 +768,21 @@ def _safe_eval_int_expr(expr, **variables):
 
 def _extract_adar_helper_sites(manager_cpp, setter_names):
     """
-    For each setter, locate the body of ``void ADAR1000Manager::<setter>``
-    and return a list of (setter, base_register, offset_expr_c, stride)
-    for every ``REG_CHn_XXX + <expr>`` memory-address assignment.
+    For each setter, locate the body of ``void`` or ``bool``
+    ``ADAR1000Manager::<setter>`` and return a list of (setter,
+    base_register, offset_expr_c, stride) for every ``REG_CHn_XXX +
+    <expr>`` memory-address assignment.
+
+    The setters originally returned ``void``. After the SPI/ADC error-
+    propagation refactor they return ``bool`` so callers can observe
+    write/read failures. The body form (``REG_CHn_XXX + <expr>``,
+    ``(channel - 1) & 0x03`` mask, ``* 2`` stride for phase I/Q) is
+    unchanged.
     """
     sites = []
     for setter in setter_names:
         m = re.search(
-            rf"void\s+ADAR1000Manager::{setter}\s*\([^)]*\)\s*\{{(.+?)^\}}",
+            rf"(?:void|bool)\s+ADAR1000Manager::{setter}\s*\([^)]*\)\s*\{{(.+?)^\}}",
             manager_cpp,
             re.MULTILINE | re.DOTALL,
         )
@@ -818,9 +825,15 @@ def _extract_adar_caller_sites(sources, setter):
     call sites fit on one line; a future multi-line refactor would drop
     callers from the scan, which the round-trip test surfaces loudly via
     `assert callers` (rather than silently missing a site).
+
+    Two terminating forms are accepted:
+      * ``setter(args);``                                — standalone call.
+      * ``ok = setter(args) && ok;`` (one or more chains) — error-propagation
+        idiom introduced by the SPI/ADC refactor where setters return
+        ``bool`` and callers AND the result into a running success flag.
     """
     out = []
-    call_re = re.compile(rf"\b{setter}\s*\(([^;]*?)\)\s*;")
+    call_re = re.compile(rf"\b{setter}\s*\(([^;]*?)\)(?:\s*&&\s*\w+)*\s*;")
     for filename, text in sources:
         for line_no, line in enumerate(text.splitlines(), start=1):
             # Skip method definition / declaration lines.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,3 +49,6 @@ select = [
 "test_*.py" = ["ARG", "T20", "ERA"]
 # Re-export modules: unused imports are intentional
 "v7/hardware.py" = ["F401"]
+# 8_Utils/Python/LUT.py is a single-purpose Verilog LUT generator whose only
+# output is `print(f"8'd{val},")` per the file's docstring intent.
+"8_Utils/Python/LUT.py" = ["T20"]


### PR DESCRIPTION
## Summary

After the recent develop merge burst (4 PRs merged into develop on 2026-05-06), upstream's `develop` CI is red on every commit since merge SHA `42987170`. The redness has two independent root causes that landed together:

1. **Ruff T201 violation in `8_Utils/Python/LUT.py:24`** — the recent restoration of `print(f"8'd{val},")` to fix the script's actual output reactivated the script as intended, but ruff's `T20` rule (configured in `pyproject.toml`) flags it because the file is not in per-file-ignores.

2. **5 failing tests in `TestTier1Adar1000ChannelRegisterRoundTrip`** — the recent SPI/ADC error-propagation refactor on `ADAR1000_Manager.cpp` changed setter return type from `void` to `bool` AND introduced the `ok = setter(...) && ok` error-chain idiom at internal call sites. The test class's parser regexes (`rf"void\s+ADAR1000Manager::{setter}…"` for body, `rf"\b{setter}\s*\(…\)\s*;"` for callers) were authored for the pre-refactor convention and no longer match.

This PR bundles two independent narrow fixes because each alone leaves develop CI red, defeating the per-PR green-CI signal. Same pattern as https://github.com/NawfalMotii79/PLFM_RADAR/pull/113 which bundled ADAR1000 channel indexing + 400 MHz reset fan-out for the same reason.

## Changes

### `pyproject.toml` — exempt `8_Utils/Python/LUT.py` from `T20`

`8_Utils/Python/LUT.py` is a single-purpose Verilog LUT generator whose only output is a stream of `print(f"8'd{val},")` lines per the file's docstring. Per-file-ignore narrowed to `LUT.py` only.

### `test_cross_layer_contract.py` — extend body-parser regex to match `bool` return type

The 4 setters `adarSet{Rx,Tx}{Phase,VgaGain}` now return `bool` (was `void`) so callers can observe SPI failures. The body form (`REG_CHn_XXX + <expr>`, `(channel - 1) & 0x03` mask, `* 2` stride for phase I/Q) is unchanged. Regex extended from `void\s+` to `(?:void|bool)\s+`. Doc comment updated.

### `test_cross_layer_contract.py` — extend caller-finder regex to match `&& <ident>` chains

The error-propagation idiom `ok = setter(args) && ok;` interposes ` && ok` between the closing `)` and the statement `;`. Regex `\)\s*;` extended to `\)(?:\s*&&\s*\w+)*\s*;` to accept zero or more `&& <ident>` chains. Doc comment updated.

## Why this is not a weakening of the test class

The test class explicitly warns against weakening (per the issue #90 lesson). This PR preserves all properties listed in the «Cannot be defeated by» comment block:

- Body extraction logic: unchanged.
- `REG_CHn_XXX + <expr>` regex: unchanged.
- Symbolic AST evaluation of offset expression: unchanged.
- Round-trip strict-equality assertion: unchanged.
- Stride detection (`* <integer>`): unchanged.

The two regex extensions only acknowledge new C++ conventions introduced by the SPI/ADC refactor:
- New return-type convention (`bool` instead of `void`).
- New error-chain idiom (`ok = func() && ok;`).

Both are pure parser updates, not logic updates.

## Test plan

- [x] Local: `uv run ruff check .` returns 0 errors.
- [x] Local: `uv run pytest 9_Firmware/tests/cross_layer/test_cross_layer_contract.py` — 51 passed, 5 skipped (Tier2VerilogCosim local-only, requires iverilog which is installed in CI).
- [x] Local: `uv run pytest 9_Firmware/9_3_GUI/test_v7.py` — 83 passed, 3 skipped (no regression).
- [x] Fork CI: all 4 jobs green on `joyshmitz/PLFM_RADAR` PR https://github.com/joyshmitz/PLFM_RADAR/pull/30 (run 25476730187, fix/develop-ci-green-restore HEAD `49055a8`).
