### PR TITLE
fix: prevent uint8_t overflow in AGC attack and recovery guard conditions (#145)

### DIFF
--- a/9_Firmware/9_1_Microcontroller/9_1_1_C_Cpp_Libraries/ADAR1000_AGC.cpp
+++ b/9_Firmware/9_1_Microcontroller/9_1_1_C_Cpp_Libraries/ADAR1000_AGC.cpp
@@ -44,7 +44,7 @@ void ADAR1000_AGC::update(bool fpga_saturation)
         saturation_event_count++;
         holdoff_counter = 0;
 
-        if (agc_base_gain >= gain_step_down + min_gain) {
+        if ((uint16_t)agc_base_gain >= (uint16_t)gain_step_down + (uint16_t)min_gain) {
             agc_base_gain -= gain_step_down;
         } else {
             agc_base_gain = min_gain;
@@ -60,7 +60,7 @@ void ADAR1000_AGC::update(bool fpga_saturation)
         if (holdoff_counter >= holdoff_frames) {
             holdoff_counter = 0;
 
-            if (agc_base_gain + gain_step_up <= max_gain) {
+            if ((uint16_t)agc_base_gain + (uint16_t)gain_step_up <= (uint16_t)max_gain) {
                 agc_base_gain += gain_step_up;
             } else {
                 agc_base_gain = max_gain;

--- a/9_Firmware/9_1_Microcontroller/tests/test_agc_outer_loop.cpp
+++ b/9_Firmware/9_1_Microcontroller/tests/test_agc_outer_loop.cpp
@@ -319,6 +319,42 @@ static void test_mixed_sequence()
 }
 
 // ---------------------------------------------------------------------------
+// Regression: attack-path uint8_t overflow (issue #145)
+static void test_attack_path_no_uint8_overflow()
+{
+    ADAR1000_AGC agc;
+    agc.enabled = true;
+    // Force min_gain + gain_step_down > 255 to trigger wrap
+    agc.min_gain = 200;
+    agc.gain_step_down = 100;
+    agc.agc_base_gain = 250;
+
+    agc.update(true); // saturation
+
+    // Without cast: 250 >= (100+200) & 0xFF = 44 --> true (wrong), gain steps down
+    // With cast:    250 >= 300 --> false (correct), gain clamped to min_gain
+    assert(agc.agc_base_gain == agc.min_gain);
+    assert(agc.saturation_event_count == 1);
+}
+
+// Regression: recovery-path uint8_t overflow
+static void test_recovery_path_no_uint8_overflow()
+{
+    ADAR1000_AGC agc;
+    agc.enabled = true;
+    agc.holdoff_frames = 1;
+    // Force agc_base_gain + gain_step_up > 255 to trigger wrap
+    agc.agc_base_gain = 250;
+    agc.gain_step_up = 50;
+    agc.max_gain = 200;
+
+    agc.update(false); // recovery step
+
+    // Without cast: (250+50) & 0xFF = 44 <= 200 --> true (wrong), gain increases past max
+    // With cast:    300 <= 200 --> false (correct), gain clamped to max_gain
+    assert(agc.agc_base_gain == agc.max_gain);
+}
+
 // Test 13: Effective gain with edge-case base_gain values
 // ---------------------------------------------------------------------------
 static void test_effective_gain_edge_cases()
@@ -362,6 +398,8 @@ int main()
     RUN_TEST(test_reset_preserves_config);
     RUN_TEST(test_saturation_counter);
     RUN_TEST(test_mixed_sequence);
+    RUN_TEST(test_attack_path_no_uint8_overflow);
+    RUN_TEST(test_recovery_path_no_uint8_overflow);
     RUN_TEST(test_effective_gain_edge_cases);
 
     printf("=== Results: %d/%d passed ===\n", tests_passed, tests_total);


### PR DESCRIPTION
## Summary

Fixes the uint8_t overflow bug in `ADAR1000_AGC::update()` reported in #145. Two additions of `uint8_t` values can silently wrap when sums exceed 255, causing incorrect AGC behavior.

## Changes

- **`ADAR1000_AGC.cpp`**: Cast `gain_step_down + min_gain` (attack path) and `agc_base_gain + gain_step_up` (recovery path) to `uint16_t` before comparison.
- **`test_agc_outer_loop.cpp`**: Two new adversarial regression tests that trigger the overflow boundary with extreme gain values.

## Bug Details

**Attack path** (line 47): `gain_step_down + min_gain` is computed as `uint8_t`. With values like step=200, min=100, the sum wraps to 44, the guard fires when it shouldn't, and gain is reduced below `min_gain` - potentially driving the LNA into an unsafe low-gain state.

**Recovery path** (line 63): `agc_base_gain + gain_step_up` is computed as `uint8_t`. With base=250, step=50, the sum wraps to 44 ≤ max_gain=200, so gain erroneously steps up past the configured ceiling.

## Testing

```bash
cd 9_Firmware/9_1_Microcontroller/tests && make clean && make
```

All 15/15 AGC tests pass (including the 2 new overflow regression tests). All other MCU tests pass. Ruff lint is clean.

## Related Issue

Closes #145